### PR TITLE
Allows other content-types than application/x-www-form-urlencoded, multipart/form-data and text/plain

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ var server = http.createServer(function (req, res) {
 			try {
 			res.setTimeout(25000);
 			res.setHeader('Access-Control-Allow-Origin', '*');
+			res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 			request(req.url.slice(1), {encoding: null}, function(error, response, body) {
       			res.write(body)
       			res.end()


### PR DESCRIPTION
I'd like to use crossorigin.me in a situation where I need to specify a different content-type than those three.