### PR TITLE
Added cache control headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,16 +56,19 @@ function handler(req, res) {
 				res.setHeader('Access-Control-Allow-Credentials', false);
 				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
-				request(req.url.slice(1), {encoding: null}, function(error, response, body) {
+				var r = request(req.url.slice(1), {encoding: null});
+				r.pipefilter = function(response, dest) {
+					for (var header in response.headers) {
+						dest.removeHeader(header);
+					}
 					for (var i=0; i<copyHeaders.length; i++) {
 						var responseHeader = response.headers[copyHeaders[i].toLowerCase()];
 						if (responseHeader) {
 							res.setHeader(copyHeaders[i], responseHeader);
 						}
 					}
-					res.write(body);
-					res.end();
-				});
+				};
+				r.pipe(res);
 			} catch (e) {
 				res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
 			}

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var favicon = fs.readFileSync('favicon.ico');
 
 var port = process.env.PORT || 8080;
 
+var copyHeaders = ['Date', 'Last-Modified', 'Expires', 'Cache-Control', 'Pragma', 'Content-Length', 'Content-Type'];
+
 var server = http.createServer(function (req, res) {
 	var d = domain.create();
 	d.on('error', function (e){
@@ -53,7 +55,14 @@ function handler(req, res) {
 				res.setHeader('Access-Control-Allow-Origin', '*');
 				res.setHeader('Access-Control-Allow-Credentials', false);
 				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
 				request(req.url.slice(1), {encoding: null}, function(error, response, body) {
+					for (var i=0; i<copyHeaders.length; i++) {
+						var responseHeader = response.headers[copyHeaders[i].toLowerCase()];
+						if (responseHeader) {
+							res.setHeader(copyHeaders[i], responseHeader);
+						}
+					}
 					res.write(body);
 					res.end();
 				});

--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ var favicon = fs.readFileSync('favicon.ico');
 
 var port = process.env.PORT || 8080;
 
-var copyHeaders = ['Date', 'Last-Modified', 'Expires', 'Cache-Control', 'Pragma', 'Content-Length', 'Content-Type'];
-
 var server = http.createServer(function (req, res) {
 	var d = domain.create();
 	d.on('error', function (e){
@@ -55,14 +53,7 @@ function handler(req, res) {
 				res.setHeader('Access-Control-Allow-Origin', '*');
 				res.setHeader('Access-Control-Allow-Credentials', false);
 				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
 				request(req.url.slice(1), {encoding: null}, function(error, response, body) {
-					for (var i=0; i<copyHeaders.length; i++) {
-						var responseHeader = response.headers[copyHeaders[i].toLowerCase()];
-						if (responseHeader) {
-							res.setHeader(copyHeaders[i], responseHeader);
-						}
-					}
 					res.write(body);
 					res.end();
 				});

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-var http = require('http')
-var request = require('request')
+var http = require('http');
+var request = require('request');
 var fs = require('fs');
 var domain = require('domain');
 var index = fs.readFileSync('index.html');
 var favicon = fs.readFileSync('favicon.ico');
 
-var port = process.env.PORT || 8080
+var port = process.env.PORT || 8080;
 
 var server = http.createServer(function (req, res) {
 	var d = domain.create();
@@ -14,7 +14,7 @@ var server = http.createServer(function (req, res) {
 		console.log('ERROR', e.stack);
 
 		res.statusCode = 500;
-		res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
+		res.end('Error: ' + ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
 	});
 
 	d.add(req);
@@ -27,7 +27,7 @@ var server = http.createServer(function (req, res) {
 }).listen(port);
 
 
-	function handler(req, res) {
+function handler(req, res) {
 	console.log(req.url);
 	switch (req.url) {
 		case "/":
@@ -43,23 +43,23 @@ var server = http.createServer(function (req, res) {
 		case "/favicon.ico":
 			res.writeHead(200);
 			res.write(favicon);
-			res.end()
+			res.end();
 		default:
 			if (req.url.indexOf('vivastreet') > -1){
 				res.end('tempbanned');
 			} else {
 			try {
-			res.setTimeout(25000);
-			res.setHeader('Access-Control-Allow-Origin', '*');
-			res.setHeader('Access-Control-Allow-Credentials', false);
-			res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-			request(req.url.slice(1), {encoding: null}, function(error, response, body) {
-      			res.write(body)
-      			res.end()
-    		})
-    		} catch (e) {
-    	   	res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
-    		}
+				res.setTimeout(25000);
+				res.setHeader('Access-Control-Allow-Origin', '*');
+				res.setHeader('Access-Control-Allow-Credentials', false);
+				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+				request(req.url.slice(1), {encoding: null}, function(error, response, body) {
+					res.write(body);
+					res.end();
+				});
+			} catch (e) {
+				res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
 			}
+		}
 	}
 }

--- a/index.js
+++ b/index.js
@@ -56,19 +56,16 @@ function handler(req, res) {
 				res.setHeader('Access-Control-Allow-Credentials', false);
 				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
-				var r = request(req.url.slice(1), {encoding: null});
-				r.pipefilter = function(response, dest) {
-					for (var header in response.headers) {
-						dest.removeHeader(header);
-					}
+				request(req.url.slice(1), {encoding: null}, function(error, response, body) {
 					for (var i=0; i<copyHeaders.length; i++) {
 						var responseHeader = response.headers[copyHeaders[i].toLowerCase()];
 						if (responseHeader) {
 							res.setHeader(copyHeaders[i], responseHeader);
 						}
 					}
-				};
-				r.pipe(res);
+					res.write(body);
+					res.end();
+				});
 			} catch (e) {
 				res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
 			}


### PR DESCRIPTION
Hi,

I'm using crossorigin.me for an in-development personal project to load arbitrary images into a JavaScript app hosted on GitHub pages. Thanks for creating this, it works nicely.

My issue is that images aren't cached because the server doesn't set any cache control headers. Images load every time they're inserted into the DOM - multiple loads if multiple instances of the image are displayed simultaneously, or if a template re-render ends up destroying and re-creating the image element. Image pre-loading is impossible.

This PR fixes that. If the proxied URL contains cache-control headers, these are copied to the response. It adds an expires "Expires" header to every response so that in the absence of any more specific instructions, responses are cached for a day. (Since "Expires" is the lowest priority cache header, any cache headers on the proxied URL - "Pragma", "Cache-Control" or another "Expires" - will override it)

Ta,

Bernie     :o)

P.S. oh and I couldn't resist fixing some inconsistent white space while I was in there...