### PR TITLE
Use HTTPS where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>crossorigin.me</title>
-<link rel="icon" type="image/png" href="favicon.png">
-<link href='http://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300' rel='stylesheet' type='text/css'>
+<link rel="icon" href="favicon.png">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300">
 <style>
 html, body {
 	min-width: 100%;
@@ -78,7 +78,7 @@ code {
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-42726363-5', 'auto');
   ga('send', 'pageview');
@@ -107,22 +107,22 @@ CoinWidgetCom.go({
 <br />
 
 <h3><a name="what" href="#what">What's a "CORS proxy"?</a></h3>
-<p>A <a href="http://en.wikipedia.org/wiki/Cross-origin_resource_sharing">CORS</a> proxy is a service that allows developers (probably you) to access resources from other websites, without having to own that website. </p>
+<p>A <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">CORS</a> proxy is a service that allows developers (probably you) to access resources from other websites, without having to own that website. </p>
 <br />
 
 <h3><a name="why" href="#why">Why does this site exist?</a></h3>
-<p>A popular CORS proxy, corsproxy.com, recently disappeared. Several <a href="http://phosphorus.github.io">cool projects</a> relied on CORS proxy, so I decided to set up a replacement service.</p>
+<p>A popular CORS proxy, corsproxy.com, recently disappeared. Several <a href="https://phosphorus.github.io/">cool projects</a> relied on CORS proxy, so I decided to set up a replacement service.</p>
 
 <br />
 <h3><a name="how" href="#how">How do I use it?</a></h3>
 <p>It's really easy. When you need to access a resource from a website that isn't CORS-enabled, append 'http://crossorigin.me' to the beginning of that URL. For example, if you wanted to grab the Google homepage, your code would request</p>
 <code>
-http://crossorigin.me/http://google.com
+http://crossorigin.me/https://google.com
 </code>
 <p>Remember to keep the 'http://' or 'https://' after 'crossorigin.me/'.
 <br />
 <h3><a name="who" href="#who">Who set this up?</a></h3>
-<p><a href="http://technoboy10.tk">I</a> <a href="http://github.com/technoboy10">did</a>! I'm technoboy10, a software geek who also likes hardware. I would also appreciate it if you donated some BTC by clicking the donation button at the top of the page - domains aren't free! <b>Special thanks to @kentonue on Twitter for donating - crossorigin.me will live for a couple of years now!</b></p>
+<p><a href="http://technoboy10.tk">I</a> <a href="https://github.com/technoboy10">did</a>! I'm technoboy10, a software geek who also likes hardware. I would also appreciate it if you donated some BTC by clicking the donation button at the top of the page - domains aren't free! <b>Special thanks to @kentonue on Twitter for donating - crossorigin.me will live for a couple of years now!</b></p>
 <br />
 <h3><a name="security" href="#security">AAAAH SO INSECURE!!!</a></h3>
 <p>...not really. By default, CORS requests do <b>not</b> send or set cookies, and neither does crossorigin.me. I take security very seriously, and I'll do my best to plug any serious security holes. Oh, and crossorigin.me is <a href="http://github.com/technoboy10/crossorigin.me">open source</a>, so please feel free to fix any security issues you find. :) </p>


### PR DESCRIPTION
This avoids some of the mixed content warnings when visiting the page over HTTPS.

The only remaining problem is CoinWidget, which is only available over HTTP: https://github.com/scottycc/coinwidget.com/issues/10

Ref. #14.