### PR TITLE
Optimizations and made allowOriginalHeaders & banned urls external JSON files

### DIFF
--- a/allowedOriginalHeaders.json
+++ b/allowedOriginalHeaders.json
@@ -1,0 +1,10 @@
+[
+	"Date",
+	"Last-Modified",
+	"Expires",
+	"Cache-Control",
+	"Pragma",
+	"Content-Length",
+	"Content-Type",
+	"Access-Control-Allow"
+]

--- a/bannedUrls.json
+++ b/bannedUrls.json
@@ -1,0 +1,4 @@
+[
+	"porn",
+	"vivastreet"
+]

--- a/index.js
+++ b/index.js
@@ -5,68 +5,80 @@ var http = require('http'),
 	domain = require('domain'),
 	index = require('zlib').gzipSync(fs.readFileSync('index.html'))
 	favicon = require('zlib').gzipSync(fs.readFileSync('favicon.ico'))
+	faviconPNG = require('zlib').gzipSync(fs.readFileSync('favicon.png'))
 	port = process.env.PORT || 8080,
 	allowedOriginalHeaders = new RegExp('^' + require('./allowedOriginalHeaders.json').join('|'), 'i')
-	bannedUrls = new RegExp(require('./bannedUrls.json').join('|'), 'i')
+	bannedUrls = new RegExp(require('./bannedUrls.json').join('|'), 'i'),
+	requestOptions = {
+		encoding: null,
+		rejectUnauthorized: false,
+		headers: {
+			'accept-encoding': 'identity'
+		}
+	},
+	server = http.createServer(function (req, res) {
+		var d = domain.create();
+		d.on('error', function (e){
+			console.log('ERROR', e.stack);
 
-var server = http.createServer(function (req, res) {
-	var d = domain.create();
-	d.on('error', function (e){
-		console.log('ERROR', e.stack);
+			res.statusCode = 500;
+			res.end('Error: ' + ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
+		});
 
-		res.statusCode = 500;
-		res.end('Error: ' + ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
-	});
+		d.add(req);
+		d.add(res);
 
-	d.add(req);
-	d.add(res);
-
-	d.run(function() {
-		handler(req, res);
-	});
-}).listen(port);
-
-
-function handler(req, res) {
-	switch (req.url) {
-		case "/":
-		case "/index.html" :
-			res.setHeader('content-encoding', 'gzip')
-			res.setHeader('content-type', 'text/html')
-			res.writeHead(200);
-			res.write(index);
-			res.end();
-		case "/favicon.ico":
-			res.setHeader('content-encoding', 'gzip')
-			res.setHeader('content-type', 'image/x-icon')
-			res.writeHead(200);
-			res.write(favicon);
-			res.end();
-		case "/favicon.ico":
-			break;
-		default:
-			if (bannedUrls.test(req.url)) {
-				res.writeHead(403);
-				res.end('FORBIDDEN');
-			} else {
-			try {
-				res.setTimeout(25000);
-				res.setHeader('Access-Control-Allow-Origin', '*');
-				res.setHeader('Access-Control-Allow-Credentials', false);
-				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
-				var r = request(req.url.slice(1), {encoding: null, rejectUnauthorized: false});
-				r.pipefilter = function(response, dest) {
-					for (var header in response.headers) {
-						if (!allowedOriginalHeaders.test(header)) {
-							dest.removeHeader(header);	
+		d.run(function() {
+			handler(req, res);
+		});
+	}).listen(port),
+	handler = function handler(req, res) {
+		switch (req.url) {
+			case "/":
+			case "/index.html" :
+				res.setHeader('content-type', 'text/html')
+				res.setHeader('content-encoding', 'gzip')
+				res.writeHead(200);
+				res.write(index);
+				res.end();
+				break;
+			case "/favicon.ico":
+				res.setHeader('content-encoding', 'gzip')
+				res.setHeader('content-type', 'image/x-icon')
+				res.writeHead(200);
+				res.write(favicon);
+				res.end();
+				break;
+			case "/favicon.png":
+				res.setHeader('content-encoding', 'gzip')
+				res.setHeader('content-type', 'image/png')
+				res.writeHead(200);
+				res.write(faviconPNG);
+				res.end();
+				break;
+			default:
+				if (bannedUrls.test(req.url)) {
+					res.writeHead(403);
+					res.end('FORBIDDEN');
+				} else {
+				try {
+					res.setTimeout(25000);
+					res.setHeader('Access-Control-Allow-Origin', '*');
+					res.setHeader('Access-Control-Allow-Credentials', false);
+					res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+					res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
+					var r = request(req.url.slice(1), requestOptions);
+					r.pipefilter = function(response, dest) {
+						for (var header in response.headers) {
+							if (!allowedOriginalHeaders.test(header)) {
+								dest.removeHeader(header);	
+							}
 						}
-					}
-				};
-				r.pipe(res);
-			} catch (e) {
-				res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
+					};
+					r.pipe(res);
+				} catch (e) {
+					res.end('Error: ' +  ((e instanceof TypeError) ? "make sure your URL is correct" : String(e)));
+				}
 			}
 		}
 	}
-}


### PR DESCRIPTION
Love the service, thought I could say thanks by throwing a few improvements yourway!

 - Separated the hard coded allowedOriginalHeaders into a JSON file that gets loaded at runtime and converted into a RegExp
 - Separated the hard coded list of banned urls/url-partials into a JSON file that gets loaded at runtime and  converted into a RegExp
 - Added GZip to the index and favicon; improves transfer sizes considerably (index.html was 6kb gzipped 2.8KB; favicon.ico was 2.2KB gzipped 558bytes)
 - Added mime types to index and favicon
 - Changed banned url response to http code 403 (FORBIDDEN)
 - Removed the console.log at the top of the handler function
 - Combined the the "/" and "/index.html" switch cases (as they are handling the same thing)

Notes: I've also removed the `var` from each of the top variables, except the first one, and used commas to let the localization flow to each variable; it's identical in effect, but stylistically different; please let me know if you would want it reverted and I can do so :)
