### PR TITLE
Added the content-encoding header for gzipped and uncompressed

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ var http = require('http'),
 							dest.removeHeader(header);	
 						}
 						if (options.flags.gzip === true && header === 'content-encoding') dest.setHeader('content-encoding', response.headers[header])
+						else dest.setHeader('content-encoding', 'identity')
 					}
 				};
 				r.pipe(res);


### PR DESCRIPTION
Added the header `Content-Encoding: identity` to see if cloudflare will respect it and stop gzipping everything see: https://github.com/technoboy10/crossorigin.me/issues/19#issuecomment-161474645 for more details.

Snip: 
There's some cryptic message about it preserving the `content-encoding` [headers value](https://support.cloudflare.com/hc/en-us/articles/200168086-Does-CloudFlare-gzip-resources-), and I did find in the [HTTP/1.1 RFC](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) that a value of `identity` is always accepted; so I've made the change to always send `identity` or `gzip`and have made a pull request