### PR TITLE
Enable seeking for streaming media (Added 'Range' to allowed headers & set 'Accept-Ranges, bytes' response header)

### DIFF
--- a/allowedOriginalHeaders.json
+++ b/allowedOriginalHeaders.json
@@ -6,5 +6,6 @@
 	"Pragma",
 	"Content-Length",
 	"Content-Type",
-	"Access-Control-Allow"
+	"Access-Control-Allow",
+	"Range"
 ]

--- a/index.js
+++ b/index.js
@@ -104,13 +104,14 @@ var http = require('http'),
 				res.setHeader('Access-Control-Allow-Origin', '*');
 				res.setHeader('Access-Control-Allow-Credentials', false);
 				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+				res.setHeader('Accept-Ranges', 'bytes');
 				res.setHeader('Expires', new Date(Date.now() + 86400000).toUTCString()); // one day in the future
 				var options = handleOptions(res, req),
 					r = request(options);
 				r.pipefilter = function(response, dest) {
 					for (var header in response.headers) {
 						if (!allowedOriginalHeaders.test(header)) {
-							dest.removeHeader(header);	
+							dest.removeHeader(header);
 						}
 						if (options.flags.gzip === true && header === 'content-encoding') dest.setHeader('content-encoding', response.headers[header])
 					}


### PR DESCRIPTION
Accepting 'Range' header and sending 'accept-rages: bytes' header allows media to be played with seeking by specifying .currentTime property.

Helped me when loading .mp3 with corsproxy.

As referenced here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Configuring_servers_for_Ogg_media#Handle_HTTP_1.1_byte_range_requests_correctly