### PR TITLE
Add support for custom request headers

### DIFF
--- a/allowedRequestHeaders.json
+++ b/allowedRequestHeaders.json
@@ -1,0 +1,4 @@
+[
+  "Accept",
+  "Content-Type"
+]

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ var http = require('http'),
 	port = process.env.PORT || 8080,
 	allowedOriginalHeaders = new RegExp('^' + require('./allowedOriginalHeaders.json').join('|'), 'i'),
 	allowedRequestHeaders = require('./allowedRequestHeaders.json'),
-	_ = require('lodash'),
 	bannedUrls = new RegExp(require('./bannedUrls.json').join('|'), 'i'),
 	defaultOptions = {
 		gzip:true
@@ -85,7 +84,7 @@ var http = require('http'),
 			return str.toLowerCase();
 		}
 		//add headers from original request
-		for ( var header of _.map(allowedRequestHeaders, toLower)) {
+		for ( var header of allowedRequestHeaders.map(toLower)) {
 			opts.headers[header] = req.headers[header]
 		}
 		return opts

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ var http = require('http'),
 	faviconPNG = fsRead('favicon.png')
 	faviconPNGGZip = gzip(faviconPNG)
 	port = process.env.PORT || 8080,
-	allowedOriginalHeaders = new RegExp('^' + require('./allowedOriginalHeaders.json').join('|'), 'i')
+	allowedOriginalHeaders = new RegExp('^' + require('./allowedOriginalHeaders.json').join('|'), 'i'),
+	allowedRequestHeaders = require('./allowedRequestHeaders.json'),
+	_ = require('lodash'),
 	bannedUrls = new RegExp(require('./bannedUrls.json').join('|'), 'i'),
 	defaultOptions = {
 		gzip:true
@@ -78,6 +80,14 @@ var http = require('http'),
 						break;
 				}
 			}
+
+		var toLower = function (str) {
+			return str.toLowerCase();
+		}
+		//add headers from original request
+		for ( var header of _.map(allowedRequestHeaders, toLower)) {
+			opts.headers[header] = req.headers[header]
+		}
 		return opts
 	},
 	handler = function handler(req, res) {
@@ -110,7 +120,7 @@ var http = require('http'),
 				r.pipefilter = function(response, dest) {
 					for (var header in response.headers) {
 						if (!allowedOriginalHeaders.test(header)) {
-							dest.removeHeader(header);	
+							dest.removeHeader(header);
 						}
 						if (options.flags.gzip === true && header === 'content-encoding') dest.setHeader('content-encoding', response.headers[header])
 					}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "request": "^2.40.0",
-    "lodash": "latest"
+    "request": "^2.40.0"
   },
   "keywords": [
     "cors",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "request": "^2.40.0"
+    "request": "^2.40.0",
+    "lodash": "latest"
   },
   "keywords": [
     "cors",


### PR DESCRIPTION
As mentioned in issue #33, I was having trouble talking to APIs who required some headers to be present such as `Accept: application/json` along with `Content-Type`.

In order to support this, I've added a configuration file for whitelisting headers we can pass on. To make my life easier I have added lodash. If the extra dependency isn't an issue we can refactor a few areas using some lodash sugar.