### PR TITLE
Require `Origin` header

### DIFF
--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -18,6 +18,12 @@ function get (req, res, next) {
 
     var url = req.params[0];
 
+    // require the Origin header
+    if (!req.headers['origin']) {
+        res.statusCode = 403;
+        return res.end('Origin: header is required');
+    }
+
     // forward client headers to server
     var headers = {};
     for (var header in req.headers) {

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -1,5 +1,9 @@
 const request = require('request');
 
+let requireHeader = [
+    'origin',
+    'x-requested-with',
+];
 let clientHeadersBlacklist = new Set([
     'host',
     'cookie',
@@ -18,11 +22,18 @@ function get (req, res, next) {
 
     var url = req.params[0];
 
-    // require the Origin header
-    if (!req.headers['origin']) {
+    // require CORS header
+    if (!requireHeader.some(header => req.headers[header])) {
         res.statusCode = 403;
         return res.end('Origin: header is required');
     }
+
+    // TODO redirect same origin
+    /* from cors-anywhere: boolean redirectSameOrigin - If true, requests to
+     * URLs from the same origin will not be proxied but redirected. The
+     * primary purpose for this option is to save server resources by
+     * delegating the request to the client (since same-origin requests should
+     * always succeed, even without proxying). */
 
     // forward client headers to server
     var headers = {};

--- a/tests/integration/cors.js
+++ b/tests/integration/cors.js
@@ -6,8 +6,15 @@ describe('Simple CORS request', function () {
     it('should include the correct headers', function (done) {
         server
         .get('/https://google.com')
+        .set('Origin', 'http://example.com')
         .expect('Access-Control-Allow-Origin', '*')
         .expect(200, done);
+    });
+
+    it('should require the Origin header', function (done) {
+        server
+        .get('/https://google.com')
+        .expect(403, done);
     });
 });
 
@@ -21,3 +28,5 @@ describe('CORS Preflight', function () {
         .expect(200, done);
     });
 });
+
+

--- a/tests/integration/limits.js
+++ b/tests/integration/limits.js
@@ -6,6 +6,7 @@ describe('Large file request', function () {
     it('should only serve 2MB of data', function (done) { // Will attempt to fetch a 3.1MB file
         server
         .get('/https://www.dropbox.com/s/pc97egxsgy1qjq3/big.jpg?dl=1')
+        .set('Origin', 'http://example.com')
         .expect(function (res) {
             res.body.length < 2e6;
         })


### PR DESCRIPTION
Based on the previous PR #68, this delightful piece of code sends a 403 if people try to access crossorigin from:

- the same origin (ie. crossorigin.me)
- a browser, without using XHR
- anything that doesn't set the Origin header

Pros:

- Harder to abuse the proxy for casual browsing, eg <http://crossorigin.me/http://scratch.mit.edu/> or <http://crossorigin.me/http://imgur.com>

Cons:

- Not as easy to debug your code?
- Trivially workaroundable -- `curl -H 'Origin: foo' ...`