### PR TITLE
Fix #76: Support query strings.

### DIFF
--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -20,7 +20,7 @@ function get (req, res, next) {
 
     res.header('Access-Control-Allow-Origin', '*'); // Actually do the CORS thing! :)
 
-    var url = req.params[0];
+    var url = decodeURIComponent(req.params[0]);
 
     // require CORS header
     if (!requireHeader.some(header => req.headers[header])) {


### PR DESCRIPTION
This is a suggested fix for #76. Urls passed to the service should be encoded, especially the query string part, and so the server should decode the received parameter.

That means you should now pass urls at least partially encoded, eg. `https://crossorigin.me/http://api.tvmaze.com/search/shows%3Fq=boo` (note the `%3F`, which is `?` urlencoded)

Tested locally, works fine and fixes the issue. Cors tests are broken but were so previously.

Oh and, happy new year!