### PR TITLE
Implement POST requests

### DIFF
--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -93,15 +93,7 @@ function get (req, res, next) {
     next();
 }
 
-/*
-post and put handlers both handle sending data to servers (NOT FINISHED YET)
-*/
 function post (req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*'); // Actually do the CORS thing! :)
-    next();
-}
-
-function put (req, res, next) {
     res.header('Access-Control-Allow-Origin', '*'); // Actually do the CORS thing! :)
 
     var url = req.params[0];
@@ -133,7 +125,7 @@ function put (req, res, next) {
     headers['X-Fowarded-For'] = (forwardedFor ? forwardedFor + ',' : '') + req.connection.remoteAddress;
     req.pipe(
         request
-        .put(url, {headers})
+        .post(url, {headers})
         .on('data', function (chunk) {
             data += chunk.length;
             if (data > sizeLimit){
@@ -172,4 +164,4 @@ function opts (req, res, next) { // Couple of lines taken from http://stackoverf
     next();
 }
 
-module.exports = {get, post, put, opts};
+module.exports = {get, post, opts};

--- a/modules/server.js
+++ b/modules/server.js
@@ -34,9 +34,7 @@ server.opts('/', proxy.opts);
 
 // Request handler configuration (for free tier)
 server.get(/^\/(https?:\/\/.+)/, freeTier, proxy.get);
+server.post(/^\/(http:\/\/.+)/, freeTier, proxy.post);
 
-// These aren't *quite* ready for prime time
-//server.post(/^\/(http:\/\/.+)/, freeTier, proxy.post);
-//server.put(/^\/(http:\/\/.+)/, freeTier, proxy.put);
 
 module.exports = server;

--- a/tests/integration/cors.js
+++ b/tests/integration/cors.js
@@ -2,7 +2,7 @@
 const supertest = require('supertest');
 const server = supertest(require('../../modules/server.js'));
 
-describe('Simple CORS request', function () {
+describe('GET with CORS', function () {
     it('should include the correct headers', function (done) {
         server
         .get('/https://google.com')
@@ -23,6 +23,24 @@ describe('Simple CORS request', function () {
         .set('Origin', 'http://example.com')
         .expect('Access-Control-Allow-Origin', '*')
         .expect(302, done); // For some reason I'm getting 302 statuses instead of 200???
+    });
+});
+
+describe('POST with CORS', function () {
+    it('should include the correct headers', function (done) {
+        server
+        .post('/http://posttestserver.com/post.php')
+        .set('Origin', 'http://example.com')
+        .send({'data': 'crossorigin.me test'})
+        .expect('Access-Control-Allow-Origin', '*')
+        .expect(302, done); // Getting 302 instead of 200. No clue why.
+    });
+
+    it('should require the Origin header', function (done) {
+        server
+        .post('/http://posttestserver.com/post.php')
+        .send('POST requests without Origin header should fail')
+        .expect(403, done);
     });
 });
 


### PR DESCRIPTION
This resolves #6 by adding and enabling POST requests. PUT requests have been removed in favor of only implementing ["simple"](https://www.w3.org/TR/cors/#terminology) methods.